### PR TITLE
Update ember-model for Ember 1.12 compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-model",
-  "version": "0.0.11",
+  "version": "0.0.21",
   "main": "ember-model.js",
   "dependencies": {
     "ember": "~1.9"

--- a/ember-model.js
+++ b/ember-model.js
@@ -539,6 +539,15 @@ function hasCachedValue(object, key) {
   }
 }
 
+function isDescriptor(value) {
+  // Ember < 1.11
+  if (Ember.Descriptor !== undefined) {
+    return value instanceof Ember.Descriptor;
+  }
+  // Ember >= 1.11
+  return value && typeof value === 'object' && value.isDescriptor;
+}
+
 Ember.run.queues.push('data');
 
 Ember.Model = Ember.Object.extend(Ember.Evented, {
@@ -651,7 +660,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   didDefineProperty: function(proto, key, value) {
-    if (value instanceof Ember.Descriptor) {
+    if (isDescriptor(value)) {
       var meta = value.meta();
       var klass = proto.constructor;
 
@@ -2022,7 +2031,7 @@ Ember.onLoad('Ember.Application', function(Application) {
     name: "store",
 
     initialize: function(container, application) {
-      application.register('store:main', container.lookupFactory('store:application') || Ember.Model.Store);
+      application.register('store:main', application && application.Store || Ember.Model.Store);
 
       application.inject('route', 'store', 'store:main');
       application.inject('controller', 'store', 'store:main');

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -30,6 +30,15 @@ function hasCachedValue(object, key) {
   }
 }
 
+function isDescriptor(value) {
+  // Ember < 1.11
+  if (Ember.Descriptor !== undefined) {
+    return value instanceof Ember.Descriptor;
+  }
+  // Ember >= 1.11
+  return value && typeof value === 'object' && value.isDescriptor;
+}
+
 Ember.run.queues.push('data');
 
 Ember.Model = Ember.Object.extend(Ember.Evented, {
@@ -142,7 +151,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   didDefineProperty: function(proto, key, value) {
-    if (value instanceof Ember.Descriptor) {
+    if (isDescriptor(value)) {
       var meta = value.meta();
       var klass = proto.constructor;
 

--- a/packages/ember-model/lib/store.js
+++ b/packages/ember-model/lib/store.js
@@ -61,7 +61,7 @@ Ember.onLoad('Ember.Application', function(Application) {
     name: "store",
 
     initialize: function(container, application) {
-      application.register('store:main', container.lookupFactory('store:application') || Ember.Model.Store);
+      application.register('store:main', application && application.Store || Ember.Model.Store);
 
       application.inject('route', 'store', 'store:main');
       application.inject('controller', 'store', 'store:main');


### PR DESCRIPTION
@ckung I didn't use `Ember.get` for `application.Store` because the examples I saw upstream imply that it can be accessed as standard POJO property. E.g. https://github.com/ebryn/ember-model/pull/427/files#diff-fcb4fcb0bdc308408dd55316e7fecae8R66