### PR TITLE
Ember 2.3 deprecations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.16",
   "main": "ember-model.js",
   "dependencies": {
-    "ember": "~1.13"
+    "ember": "2.3.1"
   },
   "devDependencies": {
     "qunit": "~1.11"

--- a/ember-model.js
+++ b/ember-model.js
@@ -471,7 +471,7 @@ Ember.HasManyArray = Ember.ManyArray.extend({
 
     if (record) {
       if (! record.container) {
-        record.container = container;
+        Ember.setOwner(record, container);
       }
       return record;
     }
@@ -512,14 +512,13 @@ Ember.EmbeddedHasManyArray = Ember.ManyArray.extend({
     if (reference.record) {
       record = reference.record;
     } else {
-      record = klass.create({ _reference: reference, container: container });
+      record = klass.create({ _reference: reference });
       reference.record = record;
       if (attrs) {
         record.load(attrs[primaryKey], attrs);
       }
     }
-
-    record.container = container;
+    Ember.setOwner(record, container);
     return record;
   },
 
@@ -1234,7 +1233,7 @@ Ember.Model.reopenClass({
     var ref = this._getReferenceById(id);
     if(ref && ref.record) {
       if (! ref.record.container) {
-        ref.record.container = container;
+        Ember.setOwner(ref.record, container);
       }
       return ref.record;
     }
@@ -1252,8 +1251,8 @@ Ember.Model.reopenClass({
           attrs = {isLoaded: false};
 
       attrs[primaryKey] = id;
-      attrs.container = container;
       record = this.create(attrs);
+      Ember.setOwner(record, container);
       if (!this.transient) {
         var sideloadedData = this.sideloadedData && this.sideloadedData[id];
         if (sideloadedData) {

--- a/packages/ember-model/lib/belongs_to.js
+++ b/packages/ember-model/lib/belongs_to.js
@@ -3,8 +3,9 @@ var get = Ember.get,
     set = Ember.set;
 
 function storeFor(record) {
-  if (record.container) {
-    return record.container.lookup('store:main');
+  var owner = Ember.getOwner(record);
+  if (owner) {
+    return owner.lookup('store:main');
   }
 
   return null;
@@ -120,7 +121,10 @@ Ember.Model.reopen({
     if (meta.options.embedded) {
       var primaryKey = get(type, 'primaryKey'),
         id = idOrAttrs[primaryKey];
-      record = type.create({ isLoaded: false, id: id, container: this.container });
+      var owner = Ember.getOwner(this);
+      record = type.create({ isLoaded: false, id: id });
+      Ember.setOwner(record, owner);
+
       record.load(id, idOrAttrs);
     } else {
       if (store) {

--- a/packages/ember-model/lib/has_many.js
+++ b/packages/ember-model/lib/has_many.js
@@ -8,7 +8,8 @@ function getType(record) {
     this.type = get(Ember.lookup, this.type);
 
     if (!this.type) {
-      var store = record.container.lookup('store:main');
+      var owner = Ember.getOwner(record);
+      var store = owner.lookup('store:main');
       this.type = store.modelFor(type);
       this.type.reopenClass({ adapter: store.adapterFor(type) });
     }
@@ -28,7 +29,8 @@ Ember.hasMany = function(type, options) {
       Ember.assert("Type cannot be empty", !Ember.isEmpty(type));
 
       var key = options.key || propertyKey;
-      return this.getHasMany(key, type, meta, this.container);
+      var owner = Ember.getOwner(this);
+      return this.getHasMany(key, type, meta, owner);
     },
     set: function(propertyKey, newContentArray, existingArray) {
       return existingArray.setObjects(newContentArray);
@@ -37,7 +39,7 @@ Ember.hasMany = function(type, options) {
 };
 
 Ember.Model.reopen({
-  getHasMany: function(key, type, meta, container) {
+  getHasMany: function(key, type, meta, owner) {
     var embedded = meta.options.embedded,
         collectionClass = embedded ? Ember.EmbeddedHasManyArray : Ember.HasManyArray;
 
@@ -47,9 +49,10 @@ Ember.Model.reopen({
       content: this._getHasManyContent(key, type, embedded),
       embedded: embedded,
       key: key,
-      relationshipKey: meta.relationshipKey,
-      container: container
+      relationshipKey: meta.relationshipKey
     });
+
+    Ember.setOwner(collection, owner);
 
     this._registerHasManyArray(collection);
 

--- a/packages/ember-model/lib/has_many_array.js
+++ b/packages/ember-model/lib/has_many_array.js
@@ -194,7 +194,7 @@ Ember.HasManyArray = Ember.ManyArray.extend({
         record = reference.record;
 
     if (record) {
-      if (! record.container) {
+      if (! Ember.getOwner(record)) {
         Ember.setOwner(record, owner);
       }
       return record;
@@ -235,14 +235,15 @@ Ember.EmbeddedHasManyArray = Ember.ManyArray.extend({
     var record;
     if (reference.record) {
       record = reference.record;
+      Ember.setOwner(record, owner);
     } else {
       record = klass.create({ _reference: reference });
       reference.record = record;
+      Ember.setOwner(record, owner);
       if (attrs) {
         record.load(attrs[primaryKey], attrs);
       }
     }
-    Ember.setOwner(record, owner);
     return record;
   },
 

--- a/packages/ember-model/lib/has_many_array.js
+++ b/packages/ember-model/lib/has_many_array.js
@@ -194,7 +194,7 @@ Ember.HasManyArray = Ember.ManyArray.extend({
 
     if (record) {
       if (! record.container) {
-        record.container = container;
+        Ember.setOwner(record, container);
       }
       return record;
     }
@@ -235,14 +235,13 @@ Ember.EmbeddedHasManyArray = Ember.ManyArray.extend({
     if (reference.record) {
       record = reference.record;
     } else {
-      record = klass.create({ _reference: reference, container: container });
+      record = klass.create({ _reference: reference });
       reference.record = record;
       if (attrs) {
         record.load(attrs[primaryKey], attrs);
       }
     }
-
-    record.container = container;
+    Ember.setOwner(record, container);
     return record;
   },
 

--- a/packages/ember-model/lib/has_many_array.js
+++ b/packages/ember-model/lib/has_many_array.js
@@ -43,7 +43,8 @@ Ember.ManyArray = Ember.RecordArray.extend({
     // need to add observer if it wasn't materialized before
     var observerNeeded = (content[idx].record) ? false : true;
 
-    var record = this.materializeRecord(idx, this.container);
+    var owner = Ember.getOwner(this);
+    var record = this.materializeRecord(idx, owner);
 
     if (observerNeeded) {
       var isDirtyRecord = record.get('isDirty'), isNewRecord = record.get('isNew');
@@ -186,7 +187,7 @@ Ember.ManyArray = Ember.RecordArray.extend({
 });
 
 Ember.HasManyArray = Ember.ManyArray.extend({
-  materializeRecord: function(idx, container) {
+  materializeRecord: function(idx, owner) {
     var klass = get(this, 'modelClass'),
         content = get(this, 'content'),
         reference = content.objectAt(idx),
@@ -194,11 +195,11 @@ Ember.HasManyArray = Ember.ManyArray.extend({
 
     if (record) {
       if (! record.container) {
-        Ember.setOwner(record, container);
+        Ember.setOwner(record, owner);
       }
       return record;
     }
-    return klass._findFetchById(reference.id, false, container);
+    return klass._findFetchById(reference.id, false, owner);
   },
 
   toJSON: function() {
@@ -224,7 +225,7 @@ Ember.EmbeddedHasManyArray = Ember.ManyArray.extend({
     return record; // FIXME: inject parent's id
   },
 
-  materializeRecord: function(idx, container) {
+  materializeRecord: function(idx, owner) {
     var klass = get(this, 'modelClass'),
         primaryKey = get(klass, 'primaryKey'),
         content = get(this, 'content'),
@@ -241,7 +242,7 @@ Ember.EmbeddedHasManyArray = Ember.ManyArray.extend({
         record.load(attrs[primaryKey], attrs);
       }
     }
-    Ember.setOwner(record, container);
+    Ember.setOwner(record, owner);
     return record;
   },
 

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -281,8 +281,9 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   reload: function() {
+    var owner = Ember.getOwner(this);
     this.getWithDefault('_dirtyAttributes', []).clear();
-    return this.constructor.reload(this.get(get(this.constructor, 'primaryKey')), this.container);
+    return this.constructor.reload(this.get(get(this.constructor, 'primaryKey')), owner);
   },
 
   revert: function() {
@@ -620,8 +621,8 @@ Ember.Model.reopenClass({
   _currentBatchRecordArrays: null,
   _currentBatchDeferreds: null,
 
-  reload: function(id, container) {
-    var record = this.cachedRecordForId(id, container);
+  reload: function(id, owner) {
+    var record = this.cachedRecordForId(id, owner);
     record.set('isLoaded', false);
     return this._fetchById(record, id);
   },
@@ -802,13 +803,14 @@ Ember.Model.reopenClass({
   },
 
   // FIXME
-  findFromCacheOrLoad: function(data, container) {
+  findFromCacheOrLoad: function(data, owner) {
     var record;
     if (!data[get(this, 'primaryKey')]) {
-      record = this.create({isLoaded: false, container: container});
+      record = this.create({isLoaded: false});
     } else {
-      record = this.cachedRecordForId(data[get(this, 'primaryKey')], container);
+      record = this.cachedRecordForId(data[get(this, 'primaryKey')], owner);
     }
+    Ember.setOwner(record, owner);
     // set(record, 'data', data);
     record.load(data[get(this, 'primaryKey')], data);
     return record;

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -700,7 +700,7 @@ Ember.Model.reopenClass({
     var ref = this._getReferenceById(id);
     if(ref && ref.record) {
       if (! ref.record.container) {
-        ref.record.container = container;
+        Ember.setOwner(ref.record, container);
       }
       return ref.record;
     }
@@ -718,8 +718,8 @@ Ember.Model.reopenClass({
           attrs = {isLoaded: false};
 
       attrs[primaryKey] = id;
-      attrs.container = container;
       record = this.create(attrs);
+      Ember.setOwner(record, container);
       if (!this.transient) {
         var sideloadedData = this.sideloadedData && this.sideloadedData[id];
         if (sideloadedData) {

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -126,6 +126,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
     // eagerly load embedded data
     var relationships = this.constructor._relationships || [], meta = Ember.meta(this), relationshipKey, relationship, relationshipMeta, relationshipData, relationshipType;
     for (var i = 0, l = relationships.length; i < l; i++) {
+      var owner = Ember.getOwner(this);
       relationshipKey = relationships[i];
       relationship = (meta.descs || this)[relationshipKey];
       relationshipMeta = relationship.meta();
@@ -133,12 +134,12 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
       if (relationshipMeta.options.embedded) {
         relationshipType = relationshipMeta.type;
         if (typeof relationshipType === "string") {
-          relationshipType = Ember.get(Ember.lookup, relationshipType) || this.container.lookupFactory('model:'+ relationshipType);
+          relationshipType = Ember.get(Ember.lookup, relationshipType) || owner._lookupFactory('model:'+ relationshipType);
         }
 
         relationshipData = data[relationshipKey];
         if (relationshipData) {
-          relationshipData.container = this.container;
+          Ember.setOwner(relationshipData, owner);
           relationshipType.load(relationshipData);
         }
       }
@@ -416,7 +417,11 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
         mapFunction = function(id) { return type._getOrCreateReferenceForId(id); };
       }
 
-      var keys = Object.keys(content).removeObject('container');
+      var allKeys = Object.keys(content);
+      var ownerKey = allKeys.find(function(key) {
+        return key.match(/^OWNER/);
+      });
+      var keys = Object.keys(content).removeObject('container').removeObject(ownerKey);
       content = keys.map(function (key) {
         return mapFunction(content[key]);
       });
@@ -489,8 +494,8 @@ Ember.Model.reopenClass({
     return this._findFetchQuery(params, true);
   },
 
-  _findFetchQuery: function(params, isFetch, container) {
-    var records = Ember.RecordArray.create({modelClass: this, _query: params, container: container});
+  _findFetchQuery: function(params, isFetch) {
+    var records = Ember.RecordArray.create({modelClass: this, _query: params});
 
     var promise = this.adapter.findQuery(this, records, params);
 
@@ -505,11 +510,13 @@ Ember.Model.reopenClass({
     return this._findFetchMany(ids, true);
   },
 
-  _findFetchMany: function(ids, isFetch, container) {
+  _findFetchMany: function(ids, isFetch, owner) {
     Ember.assert("findFetchMany requires an array", Ember.isArray(ids));
 
-    var records = Ember.RecordArray.create({_ids: ids, modelClass: this, container: container}),
+    var records = Ember.RecordArray.create({_ids: ids, modelClass: this}),
         deferred;
+
+    Ember.setOwner(records, owner);
 
     if (!this.recordArrays) { this.recordArrays = []; }
     this.recordArrays.push(records);
@@ -530,7 +537,7 @@ Ember.Model.reopenClass({
       this._currentBatchDeferreds.push(deferred);
     }
 
-    Ember.run.scheduleOnce('data', this, this._executeBatch, container);
+    Ember.run.scheduleOnce('data', this, this._executeBatch, owner);
 
     return isFetch ? deferred.promise : records;
   },
@@ -543,7 +550,7 @@ Ember.Model.reopenClass({
     return this._findFetchAll(true);
   },
 
-  _findFetchAll: function(isFetch, container) {
+  _findFetchAll: function(isFetch, owner) {
     var self = this;
 
     var currentFetchPromise = this._currentFindFetchAllPromise;
@@ -559,7 +566,9 @@ Ember.Model.reopenClass({
       }
     }
 
-    var records = this._findAllRecordArray = Ember.RecordArray.create({modelClass: this, container: container});
+    var records = this._findAllRecordArray = Ember.RecordArray.create({modelClass: this});
+
+    Ember.setOwner(records, owner);
 
     var promise = this._currentFindFetchAllPromise = this.adapter.findAll(this, records);
 
@@ -586,8 +595,8 @@ Ember.Model.reopenClass({
     return this._findFetchById(id, true);
   },
 
-  _findFetchById: function(id, isFetch, container) {
-    var record = this.cachedRecordForId(id, container),
+  _findFetchById: function(id, isFetch, owner) {
+    var record = this.cachedRecordForId(id, owner),
         isLoaded = get(record, 'isLoaded'),
         adapter = get(this, 'adapter'),
         deferredOrPromise;
@@ -637,7 +646,8 @@ Ember.Model.reopenClass({
       if (!this._currentBatchDeferreds) { this._currentBatchDeferreds = []; }
       this._currentBatchDeferreds.push(deferred);
 
-      Ember.run.scheduleOnce('data', this, this._executeBatch, record.container);
+      var owner = Ember.getOwner(record);
+      Ember.run.scheduleOnce('data', this, this._executeBatch, owner);
 
       return deferred.promise;
     } else {
@@ -645,7 +655,7 @@ Ember.Model.reopenClass({
     }
   },
 
-  _executeBatch: function(container) {
+  _executeBatch: function(owner) {
     var batchIds = this._currentBatchIds,
         batchRecordArrays = this._currentBatchRecordArrays,
         batchDeferreds = this._currentBatchDeferreds,
@@ -665,9 +675,10 @@ Ember.Model.reopenClass({
     }
 
     if (requestIds.length === 1) {
-      promise = get(this, 'adapter').find(this.cachedRecordForId(requestIds[0], container), requestIds[0]);
+      promise = get(this, 'adapter').find(this.cachedRecordForId(requestIds[0], owner), requestIds[0]);
     } else {
-      var recordArray = Ember.RecordArray.create({_ids: batchIds, container: container});
+      var recordArray = Ember.RecordArray.create({_ids: batchIds});
+      Ember.setOwner(recordArray, owner);
       if (requestIds.length === 0) {
         promise = new Ember.RSVP.Promise(function(resolve, reject) { resolve(recordArray); });
         recordArray.notifyLoaded();
@@ -696,21 +707,21 @@ Ember.Model.reopenClass({
     });
   },
 
-  getCachedReferenceRecord: function(id, container){
+  getCachedReferenceRecord: function(id, owner){
     var ref = this._getReferenceById(id);
     if(ref && ref.record) {
-      if (! ref.record.container) {
-        Ember.setOwner(ref.record, container);
+      if (! Ember.getOwner(ref.record)) {
+        Ember.setOwner(ref.record, owner);
       }
       return ref.record;
     }
     return undefined;
   },
 
-  cachedRecordForId: function(id, container) {
+  cachedRecordForId: function(id, owner) {
     var record;
     if (!this.transient) {
-      record = this.getCachedReferenceRecord(id, container);
+      record = this.getCachedReferenceRecord(id, owner);
     }
 
     if (!record) {
@@ -719,7 +730,7 @@ Ember.Model.reopenClass({
 
       attrs[primaryKey] = id;
       record = this.create(attrs);
-      Ember.setOwner(record, container);
+      Ember.setOwner(record, owner);
       if (!this.transient) {
         var sideloadedData = this.sideloadedData && this.sideloadedData[id];
         if (sideloadedData) {
@@ -821,7 +832,7 @@ Ember.Model.reopenClass({
     }, this).forEach(callback);
   },
 
-  load: function(hashes, container) {
+  load: function(hashes, owner) {
     if (Ember.typeOf(hashes) !== 'array') { hashes = [hashes]; }
 
     if (!this.sideloadedData) { this.sideloadedData = {}; }
@@ -829,7 +840,7 @@ Ember.Model.reopenClass({
     for (var i = 0, l = hashes.length; i < l; i++) {
       var hash = hashes[i],
           primaryKey = hash[get(this, 'primaryKey')],
-          record = this.getCachedReferenceRecord(primaryKey, hashes.container);
+          record = this.getCachedReferenceRecord(primaryKey, owner);
       if (record) {
         record.load(primaryKey, hash);
       } else {

--- a/packages/ember-model/lib/record_array.js
+++ b/packages/ember-model/lib/record_array.js
@@ -11,8 +11,10 @@ Ember.RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
   },
 
   loadForFindMany: function(klass) {
-    var self = this;
-    var content = get(this, '_ids').map(function(id) { return klass.cachedRecordForId(id, self.container); });
+    var owner = Ember.getOwner(this);
+    var content = get(this, '_ids').map(function(id) {
+      return klass.cachedRecordForId(id, owner);
+    });
     set(this, 'content', Ember.A(content));
     this.notifyLoaded();
   },
@@ -25,7 +27,8 @@ Ember.RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
   materializeData: function(klass, data) {
     var self = this;
     return Ember.A(data.map(function(el) {
-      return klass.findFromCacheOrLoad(el, self.container); // FIXME
+      var owner = Ember.getOwner(self);
+      return klass.findFromCacheOrLoad(el, owner); // FIXME
     }));
   },
 
@@ -33,7 +36,7 @@ Ember.RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
     var modelClass = this.get('modelClass'),
         self = this,
         promises;
-    
+
     set(this, 'isLoaded', false);
     if (modelClass._findAllRecordArray === this) {
       return modelClass.adapter.findAll(modelClass, this);

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -722,24 +722,31 @@ test("key defaults to model's property key", function() {
   deepEqual(comment.toJSON(), { article: 2 });
 });
 
-// test("non embedded belongsTo should return a record with a container", function() {
-//   var App;
-//   Ember.run(function() {
-//     App = Ember.Application.create({});
-//   });
-//   App.Article = Ember.Model.extend({
-//     id: Ember.attr(String)
-//   });
-//   App.Comment = Ember.Model.extend({
-//     article: Ember.belongsTo('article', { key: 'article_slug' })
-//   });
-//
-//   App.Article.adapter = Ember.FixtureAdapter.create();
-//   App.Article.FIXTURES = [{ id: 'first-article' }];
-//
-//   var comment = App.Comment.create({container: App.__container__});
-//   Ember.run(comment, comment.load, 1, { article_slug: 'first-article'  });
-//   var article = Ember.run(comment, comment.get, 'article');
-//   ok(article.get('container'));
-//   Ember.run(App, 'destroy');
-// });
+test("non embedded belongsTo should return a record with an owner", function() {
+  var owner = buildOwner();
+  var App;
+  Ember.run(function() {
+    App = Ember.Application.create({});
+  });
+  App.Article = Ember.Model.extend({
+    id: Ember.attr(String)
+  });
+  App.Comment = Ember.Model.extend({
+    article: Ember.belongsTo('article', { key: 'article_slug' })
+  });
+
+  App.Article.adapter = Ember.FixtureAdapter.create();
+  App.Article.FIXTURES = [{ id: 'first-article' }];
+
+  owner.register('model:article', App.Article);
+  owner.register('model:comment', App.Comment);
+  owner.register('store:main', Ember.Model.Store);
+
+  var comment = App.Comment.create();
+  Ember.setOwner(comment, owner);
+
+  Ember.run(comment, comment.load, 1, { article_slug: 'first-article'  });
+  var article = Ember.run(comment, comment.get, 'article');
+  ok(Ember.getOwner(article));
+  Ember.run(App, 'destroy');
+});

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -1,5 +1,18 @@
 module("Ember.belongsTo");
 
+function buildOwner() {
+  var Owner = Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin, {
+    init: function() {
+      this._super.apply(arguments);
+      var registry = new Ember.Registry(this._registryOptions);
+      this.__registry__ = registry;
+      this.__container__ = registry.container({ owner: this });
+    }
+  });
+
+  return Owner.create();
+}
+
 test("it exists", function() {
   ok(Ember.belongsTo);
 });
@@ -53,10 +66,12 @@ test("model can be specified with a string instead of a class", function() {
 });
 
 test("model can be specified with a string to a resolved path", function() {
+  var owner = buildOwner();
   var App;
   Ember.run(function() {
     App = Ember.Application.create({});
   });
+
   App.Article  = Ember.Model.extend({
       id: Ember.attr(String)
     });
@@ -64,7 +79,11 @@ test("model can be specified with a string to a resolved path", function() {
       article: Ember.belongsTo('article', { key: 'article', embedded: true })
     });
 
-  var comment = App.Comment.create({container: App.__container__});
+  owner.register('model:article', App.Article);
+  owner.register('model:comment', App.Comment);
+  owner.register('store:main', Ember.Model.Store);
+  var comment = App.Comment.create();
+  Ember.setOwner(comment, owner);
   Ember.run(comment, comment.load, 1, { article: { id: 'a' } });
   var article = Ember.run(comment, comment.get, 'article');
 
@@ -516,6 +535,8 @@ test("belongsTo from an embedded source is able to materialize without having to
 
   Company.load([compJson]);
   var company = Company.find(1);
+  var owner = buildOwner();
+  Ember.setOwner(company, owner);
 
   equal(company.get('projects.length'), 1);
   equal(company.get('projects.firstObject.posts.length'), 2);
@@ -701,24 +722,24 @@ test("key defaults to model's property key", function() {
   deepEqual(comment.toJSON(), { article: 2 });
 });
 
-test("non embedded belongsTo should return a record with a container", function() {
-  var App;
-  Ember.run(function() {
-    App = Ember.Application.create({});
-  });
-  App.Article = Ember.Model.extend({
-    id: Ember.attr(String)
-  });
-  App.Comment = Ember.Model.extend({
-    article: Ember.belongsTo('article', { key: 'article_slug' })
-  });
-
-  App.Article.adapter = Ember.FixtureAdapter.create();
-  App.Article.FIXTURES = [{ id: 'first-article' }];
-
-  var comment = App.Comment.create({container: App.__container__});
-  Ember.run(comment, comment.load, 1, { article_slug: 'first-article'  });
-  var article = Ember.run(comment, comment.get, 'article');
-  ok(article.get('container'));
-  Ember.run(App, 'destroy');
-});
+// test("non embedded belongsTo should return a record with a container", function() {
+//   var App;
+//   Ember.run(function() {
+//     App = Ember.Application.create({});
+//   });
+//   App.Article = Ember.Model.extend({
+//     id: Ember.attr(String)
+//   });
+//   App.Comment = Ember.Model.extend({
+//     article: Ember.belongsTo('article', { key: 'article_slug' })
+//   });
+//
+//   App.Article.adapter = Ember.FixtureAdapter.create();
+//   App.Article.FIXTURES = [{ id: 'first-article' }];
+//
+//   var comment = App.Comment.create({container: App.__container__});
+//   Ember.run(comment, comment.load, 1, { article_slug: 'first-article'  });
+//   var article = Ember.run(comment, comment.get, 'article');
+//   ok(article.get('container'));
+//   Ember.run(App, 'destroy');
+// });

--- a/packages/ember-model/tests/dirty_tracking_test.js
+++ b/packages/ember-model/tests/dirty_tracking_test.js
@@ -693,7 +693,7 @@ test("set embedded belongsTo cleans up observers", function() {
   Post.adapter = Ember.FixtureAdapter.create();
 
   function observers(obj) {
-    return Ember.meta(obj).watching['isDirty'] || 0;
+    return Ember.meta(obj)._watching['isDirty'] || 0;
   }
 
   var post = Post.create();

--- a/packages/ember-model/tests/has_many_test.js
+++ b/packages/ember-model/tests/has_many_test.js
@@ -1,5 +1,18 @@
 var get = Ember.get;
 
+function buildOwner() {
+  var Owner = Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin, {
+    init: function() {
+      this._super.apply(arguments);
+      var registry = new Ember.Registry(this._registryOptions);
+      this.__registry__ = registry;
+      this.__container__ = registry.container({ owner: this });
+    }
+  });
+
+  return Owner.create();
+}
+
 module("Ember.hasMany");
 
 test("it exists", function() {
@@ -85,6 +98,7 @@ test("model can be specified with a string instead of a class", function() {
 });
 
 test("model can be specified with a string to a resolved path", function() {
+  var owner = buildOwner();
   var App;
   Ember.run(function() {
     App = Ember.Application.create({});
@@ -101,7 +115,14 @@ test("model can be specified with a string to a resolved path", function() {
     comments: Ember.hasMany('comment', { key: 'comments', embedded: true })
   });
 
-  var article = App.Article.create({container: App.__container__});
+  owner.register('model:article', App.Article);
+  owner.register('model:comment', App.Comment);
+  owner.register('model:subcomment', App.Subcomment);
+  owner.register('store:main', Ember.Model.Store);
+  var article = App.Article.create();
+
+  Ember.setOwner(article, owner);
+
   var subcomments = {
     subcomments: Ember.A([
       {id: 'c'},
@@ -216,10 +237,10 @@ test("has many records created are available from reference cache", function() {
     projects:[{
           id: 1,
           title: 'project one title',
-          company: 1, 
-          posts: [{id: 1, title: 'title', body: 'body', project:1 }, 
+          company: 1,
+          posts: [{id: 1, title: 'title', body: 'body', project:1 },
                   {id: 2, title: 'title two', body: 'body two', project:1 }]
-      }] 
+      }]
     };
 
   Company.load([compJson]);

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -578,9 +578,7 @@ test("toJSON includes embedded relationships", function() {
 
   var json = Ember.run(article, article.toJSON);
 
-  var map = Ember.EnumerableUtils.map;
-
-  deepEqual(map(json.comments, function(c) { return c.text; }), ['uno', 'dos', 'tres'], "JSON should contain serialized records from hasMany relationship");
+  deepEqual(json.comments.map(function(c) { return c.text; }), ['uno', 'dos', 'tres'], "JSON should contain serialized records from hasMany relationship");
   equal(json.author.name, 'drogus', "JSON should contain serialized record from belongsTo relationship");
 });
 

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -1,5 +1,18 @@
 var Model, ModelWithoutID;
 
+function buildOwner() {
+  var Owner = Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin, {
+    init: function() {
+      this._super.apply(arguments);
+      var registry = new Ember.Registry(this._registryOptions);
+      this.__registry__ = registry;
+      this.__container__ = registry.container({ owner: this });
+    }
+  });
+
+  return Owner.create();
+}
+
 module("Ember.Model", {
   setup: function() {
     Model = Ember.Model.extend({
@@ -626,32 +639,31 @@ test("toJSON includes non-embedded relationships", function() {
 });
 
 test("toJSON works with string names", function() {
+  var owner = buildOwner();
   var App;
   Ember.run(function() {
     App = Ember.Application.create({});
   });
 
   var Comment = Ember.Model.extend({
-        container: App.__container__,
         id: Ember.attr(),
         text: Ember.attr()
       }),
       Author = Ember.Model.extend({
-        container: App.__container__,
         id: Ember.attr(),
         name: Ember.attr()
       }),
       Article = Ember.Model.extend({
-        container: App.__container__,
         id: 1,
         title: Ember.attr(),
         comments: Ember.hasMany('comment', { key: 'comments' }),
         author: Ember.belongsTo('author', { key: 'author' })
       });
 
-  App.registry.register('model:comment', Comment);
-  App.registry.register('model:author', Author);
-  App.registry.register('model:article', Article);
+  owner.register('model:comment', Comment);
+  owner.register('model:author', Author);
+  owner.register('model:article', Article);
+  owner.register('store:main', Ember.Model.Store);
 
   var articleData = {
     id: 1,
@@ -672,6 +684,8 @@ test("toJSON works with string names", function() {
 
 
   var article = Article.create();
+  Ember.setOwner(article, owner);
+
   Ember.run(article, article.load, articleData.id, articleData);
 
   var json = Ember.run(article, article.toJSON);

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -988,7 +988,7 @@ test("toPartialJSON returns a json of only dirty properties", function() {
   });
 
   var article = Article.create({});
-  equal(Ember.keys(article.toPartialJSON()).length, 0, 'new records should return empty object');
+  equal(Object.keys(article.toPartialJSON()).length, 0, 'new records should return empty object');
 
   article.set('author', 'Rob Stark');
   var comment = Comment.create({description:'Is he really dead?'});

--- a/packages/ember-model/tests/record_array_test.js
+++ b/packages/ember-model/tests/record_array_test.js
@@ -1,4 +1,17 @@
-var Model, container;
+var Model, owner;
+
+function buildOwner() {
+  var Owner = Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin, {
+    init: function() {
+      this._super.apply(arguments);
+      var registry = new Ember.Registry(this._registryOptions);
+      this.__registry__ = registry;
+      this.__container__ = registry.container({ owner: this });
+    }
+  });
+
+  return Owner.create();
+}
 
 function ajaxSuccess(data) {
   return new Ember.RSVP.Promise(function(resolve, reject) {
@@ -18,17 +31,18 @@ module("Ember.RecordArray", {
       {id: 2, name: 'Stefan'},
       {id: 3, name: 'Kris'}
     ];
-    container = new Ember.Registry().container();
+    owner = buildOwner();
   },
   teardown: function() { }
 });
 
-test("load creates records with container when container exists", function() {
-  var records = Ember.RecordArray.create({modelClass: Model, container: container});
+test("load creates records with owner when owner exists", function() {
+  var records = Ember.RecordArray.create({modelClass: Model});
+  Ember.setOwner(records, owner);
   Ember.run(records, records.load, Model, Model.FIXTURES);
   records.forEach(function(record){
     ok(record.get('isLoaded'));
-    ok(record.get('container'));
+    ok(Ember.getOwner(record));
   });
 });
 


### PR DESCRIPTION
Bunch of changes here... almost entirely around the fact that the container APIs are deprecated... should refer to `owner` only from here on out.

Got all the tests passing. Let me know if you have questions about this stuff.
